### PR TITLE
Minor fiddling to improve tests, and composer usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ atlassian-ide-plugin.xml
 .buildpath
 .project
 .settings
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,12 @@
     "description": "Dependency injection framework for PHP, similar to Spring",
     "keywords": ["dependencyinjection"],
     "homepage": "http://github.com/moodev/bounce",
+    "license": "ISC",
     "require": {
         "php": ">=5.3.0"
+    },
+    "require-dev": {
+        "ext-apc": ">=3.1.3"
     },
     "autoload": {
         "psr-0": {

--- a/lib/BounceAutoloader.php
+++ b/lib/BounceAutoloader.php
@@ -3,6 +3,7 @@
  * @author Jonathan Oddy <jonathan@moo.com>
  * @copyright Copyright (c) 2012, MOO Print Ltd.
  * @license ISC
+ * @deprecated Install using composer, use the composer autoloader.
  */
 namespace MooDev;
 

--- a/tests/MooDev/Bounce/Context/ApcCachedXmlApplicationContextTest.php
+++ b/tests/MooDev/Bounce/Context/ApcCachedXmlApplicationContextTest.php
@@ -12,6 +12,19 @@ require_once __DIR__ . '/../../../TestInit.php';
  */
 class ApcCachedXmlApplicationContextTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * This test case's results are only valid if APC is enabled and functional.
+     */
+    public function testTestConfig()
+    {
+        $this->assertTrue(function_exists("apc_fetch"), "APC module is not loaded.");
+        $this->assertTrue(ini_get("apc.enable_cli") == true, "apc.enable_cli must be enabled in your php.ini");
+    }
+
+    /**
+     * @depends testTestConfig
+     */
     public function testLoadFullXml()
     {
         if (!defined("DOC_DIR")) {
@@ -37,6 +50,9 @@ class ApcCachedXmlApplicationContextTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($one->explicitBool);
     }
 
+    /**
+     * @depends testTestConfig
+     */
     public function testLoadFullXmlTwice()
     {
         if (!defined("DOC_DIR")) {

--- a/tests/MooDev/Bounce/Context/BeanFactoryTest.php
+++ b/tests/MooDev/Bounce/Context/BeanFactoryTest.php
@@ -17,25 +17,24 @@ use MooDev\Bounce\Exception\BounceException;
 class BeanFactoryTest extends \PHPUnit_Framework_TestCase
 {
 
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage Invalid contextConfig. Must be a Config\Context instance
+     */
     public function testConfigGuards()
     {
         $impl = BeanFactory::getInstance(new Config\Context());
-        try {
-            $impl->contextConfig = new BounceException();
-        } catch (BounceException $e) {
-            $this->assertEquals("Invalid contextConfig. Must be a Config\Context instance", $e->getMessage());
-        }
-        $impl->contextConfig = new Config\Context();
+        $impl->contextConfig = new BounceException();
     }
 
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage No object defined with name bean
+     */
     public function testEmptyConfig()
     {
         $impl = BeanFactory::getInstance(new Config\Context());
-        try {
-            $impl->createByName("bean");
-        } catch (BounceException $e) {
-            $this->assertEquals("No object defined with name bean", $e->getMessage());
-        }
+        $impl->createByName("bean");
     }
 
     public function testSimpleInstantiate()
@@ -81,6 +80,7 @@ class BeanFactoryTest extends \PHPUnit_Framework_TestCase
 
         try {
             $beanFactory->createByName("steve");
+            $this->fail("Was able to create bean by non-existent name");
         } catch (BounceException $e) {
             $this->assertEquals("No object defined with name steve", $e->getMessage());
         }
@@ -108,6 +108,7 @@ class BeanFactoryTest extends \PHPUnit_Framework_TestCase
 
         try {
             $beanFactory->createByName("steve");
+            $this->fail("Was able to create bean by non-existent name");
         } catch (BounceException $e) {
             $this->assertEquals("No object defined with name steve", $e->getMessage());
         }
@@ -150,8 +151,8 @@ class BeanFactoryTest extends \PHPUnit_Framework_TestCase
         $context->beans["out"] = $bean;
         $bean->lookupMethods = array(new Config\LookupMethod("getInner", "in"));
         $bean->constructorArguments = array(
-                 new \MooDev\Bounce\Config\SimpleValueProvider("hello"),
-                 new \MooDev\Bounce\Config\SimpleValueProvider("world")
+                 new Config\SimpleValueProvider("hello"),
+                 new Config\SimpleValueProvider("world")
             );
 
 

--- a/tests/MooDev/Bounce/Context/XmlApplicationContextTest.php
+++ b/tests/MooDev/Bounce/Context/XmlApplicationContextTest.php
@@ -132,6 +132,10 @@ class XmlApplicationContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("simpleString", $parentBean->child->simpleString);
     }
 
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage Infinite recursion import detected
+     */
     public function testObviousImportLoop()
     {
         if (!defined("DOC_DIR")) {
@@ -141,14 +145,13 @@ class XmlApplicationContextTest extends \PHPUnit_Framework_TestCase
             define("SIMPLE_CONSTANT", "Hello!");
         }
         $xmlFile = __DIR__ . "/selfImporting.xml";
-        try {
-            new XmlApplicationContext($xmlFile);
-            $this->fail("No exception for infinite loop");
-        } catch (BounceException $e) {
-            $this->assertEquals(0, strpos($e->getMessage(), "Infinite recursion import detected"));
-        }
+        new XmlApplicationContext($xmlFile);
     }
 
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage Infinite recursion import detected
+     */
     public function testTransitiveImportLoop()
     {
         if (!defined("DOC_DIR")) {
@@ -158,12 +161,7 @@ class XmlApplicationContextTest extends \PHPUnit_Framework_TestCase
             define("SIMPLE_CONSTANT", "Hello!");
         }
         $xmlFile = __DIR__ . "/loopParent.xml";
-        try {
-            new XmlApplicationContext($xmlFile);
-            $this->fail("No exception for infinite loop");
-        } catch (BounceException $e) {
-            $this->assertEquals(0, strpos($e->getMessage(), "Infinite recursion import detected"));
-        }
+        new XmlApplicationContext($xmlFile);
     }
 
     public function testCustomNS() {

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -1,4 +1,6 @@
 <?php
 
-require_once(__DIR__ . '/../lib/BounceAutoloader.php');
+ini_set("display_errors", true);
+error_reporting(E_ALL);
+$loader = require_once(__DIR__ . "/../vendor/autoload.php");
 


### PR DESCRIPTION
Made Apc driven test check that APC's available and usable.
Switched exception tests to use expectedException and expectedExceptionMessage.
Added missing fail() cases for some exception checks that can't use the above.
Use the composer autoloader
Update the license in composer.json
