### PR TITLE
Correct bugs with proxy generation and scope.

### DIFF
--- a/lib/MooDev/Bounce/Context/XmlApplicationContext.php
+++ b/lib/MooDev/Bounce/Context/XmlApplicationContext.php
@@ -9,7 +9,6 @@ namespace MooDev\Bounce\Context;
 
 use MooDev\Bounce\Exception\BounceException;
 use MooDev\Bounce\Config;
-use MooDev\Bounce\Proxy\ProxyGeneratorFactory;
 use SimpleXMLElement;
 use MooDev\Bounce\Xml\TypeSafeParser;
 
@@ -158,7 +157,7 @@ class XmlApplicationContext extends ApplicationContext
         $bean->factoryBean = !is_null($factoryBean) ? strval($factoryBean) : null;
         $bean->factoryMethod = !is_null($factoryMethod) ? strval($factoryMethod) : null;
 
-        $bean->scope = isset($beanXml["scope"]) ? $beanXml["scope"] : null;
+        $bean->scope = isset($beanXml["scope"]) ? strval($beanXml["scope"]) : null;
 
         $bean->name = strval(!is_null($id) ? $id : $name);
 

--- a/lib/MooDev/Bounce/Proxy/Store/FilesystemProxyStore.php
+++ b/lib/MooDev/Bounce/Proxy/Store/FilesystemProxyStore.php
@@ -87,8 +87,9 @@ abstract class FilesystemProxyStore implements ProxyStore {
     public function getProxyNamespace()
     {
         if ($this->_proxyNamespace === null) {
-            $this->_proxyNamespace = $this->_baseProxyNamespace . '\C' . Base32Hex::encode($this->_getProxyDir());
+            $this->_proxyNamespace = ltrim($this->_baseProxyNamespace . '\C' . Base32Hex::encode($this->_getProxyDir()), '\\');
         }
+        return $this->_proxyNamespace;
     }
 
 

--- a/lib/MooDev/Bounce/Proxy/Store/InMemoryProxyStore.php
+++ b/lib/MooDev/Bounce/Proxy/Store/InMemoryProxyStore.php
@@ -19,6 +19,10 @@ class InMemoryProxyStore implements ProxyStore {
 
     private $_proxyNamespace;
 
+    public function __construct() {
+        $this->_proxyNamespace = 'H' . spl_object_hash($this);
+    }
+
     public function import($uniqueId, $name, $lastModified)
     {
         return true;
@@ -34,7 +38,7 @@ class InMemoryProxyStore implements ProxyStore {
 
     public function setBaseProxyNamespace($proxyNamespace)
     {
-        $this->_proxyNamespace = $proxyNamespace . '\H' . spl_object_hash($this);
+        $this->_proxyNamespace = ltrim($proxyNamespace . '\H' . spl_object_hash($this), '\\');
     }
 
     public function getProxyNamespace()

--- a/tests/MooDev/Bounce/Context/fullContext.xml
+++ b/tests/MooDev/Bounce/Context/fullContext.xml
@@ -79,4 +79,19 @@
             </list>
         </property>
     </bean>
+
+    <bean id="three" class="StdClass" scope="prototype">
+        <property name="hi"><value>foo</value></property>
+    </bean>
+
+    <bean name="four" class="StdClass">
+        <property name="goats" ref="three" />
+        <property name="stoats">
+            <bean name="blar" class="StdClass" />
+        </property>
+    </bean>
+
+    <bean name="five" class="StdClass">
+        <lookup-method name="goats" bean="three" />
+    </bean>
 </beans>

--- a/tests/MooDev/Bounce/Proxy/Store/InMemoryProxyStoreTest.php
+++ b/tests/MooDev/Bounce/Proxy/Store/InMemoryProxyStoreTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace MooDev\Bounce\Proxy\Store;
+use Mockery as m;
+
+require_once __DIR__ . '/../../../../TestInit.php';
+
+class InMemoryProxyStoreTest extends \PHPUnit_Framework_TestCase {
+
+    public function testDefaultNamespaceIsValid()
+    {
+        $store = new UniqTmpDirFilesystemProxyStore();
+        $ns = $store->getProxyNamespace();
+        eval("namespace $ns;");
+    }
+
+}
+

--- a/tests/MooDev/Bounce/Proxy/Store/UniqTmpDirFilesystemProxyStoreTest.php
+++ b/tests/MooDev/Bounce/Proxy/Store/UniqTmpDirFilesystemProxyStoreTest.php
@@ -18,5 +18,12 @@ class UniqTmpDirFilesystemProxyStoreTest extends \PHPUnit_Framework_TestCase {
         $this->assertFileNotExists(dirname($file)); // Check cleanup
     }
 
+    public function testDefaultNamespaceIsValid()
+    {
+        $store = new UniqTmpDirFilesystemProxyStore();
+        $ns = $store->getProxyNamespace();
+        eval("namespace $ns;");
+    }
+
 }
 


### PR DESCRIPTION
Convert the scope attribute to a string so that it can be serialized.
Ensure that the namespaces generated by the proxy stores don't have a leading .
