### PR TITLE
Make Bounce a config loader for Symfony DI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: php
 php:
   - "5.4"
+  - "5.5"
+  - "5.6"
+env:
+  - SYMFONY_VERSION="~2.3.0"
+  - SYMFONY_VERSION="~2.7.0"
 before_script:
-  - echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "apc.cache_by_default = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi;
+  - if [[ $TRAVIS_PHP_VERSION =~ 5.[34] ]] ; then echo 'extension="apc.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - composer require symfony/dependency-injection:${SYMFONY_VERSION} symfony/config:${SYMFONY_VERSION}
   - composer install --dev

--- a/README.md
+++ b/README.md
@@ -3,20 +3,44 @@ Bounce
 [![Build Status](https://travis-ci.org/moodev/bounce.png)](https://travis-ci.org/moodev/bounce)
 
 Bounce is a dependency injection framework for PHP, similar to a sub-set of Spring.
+It used to be a standalone framework, which did a lot at runtime, and was therefore a bit expensive.
+It's now a front end to Symfony2's DI library, which is a fair bit more developed than Bounce was.
 
 Usage
 =====
+
 Create a context XML file (see some of the examples in the tests.)
-Instantiate an ApplicationContext implementation pointed at the context XML.
-Call the ApplicationContext's get method with bean names.
-Receive beans.
-...
-profit.
+
+Then:
+
+New style using Symfony2
+------------------------
+Use the BounceFileLoader in your Symfony2 app. Both the BounceFileLoader and the Symfony XMLFileLoader will try and
+claim all .xml files, which is less than ideal. You'll probably need to introduce some kind of delegating loader that
+filters by path, or file name, or something, in front of them to prevent this. Sorry.
+
+Old style ApplicationContext interface and configs
+--------------------------------------------------
+Instantiate a SymfonyApplicationContext. This will load the provided context into a new Symfony container and wrap it
+in the old ApplicationContext interface.
+
+If you're looking for a migration path away from the Bounce XML format, but have significant usage of the
+ApplicationContext interface you could pass a different FileLoaderFactory to the SymfonyApplicationContext, which could
+allow services to be loaded from other styles of Symfony config. Sadly the bounce xml's import statement does not
+invoke the file loader, so bounce xml files cannot import things that aren't other bounce xml files.
+
+ApplicationContext interface, externally provided container
+-----------------------------------------------------------
+The SymfonyContainerBeanFactory can wrap an existing container, and be used to instantiate the plain boring
+ApplicationContext. This will give you the ApplicationContext interface, with none of the rest of bounce's config stuff.
+
+(of course there's nothing stopping you using the BounceFileLoader to load your own container for this, which is
+basically what the SymfonyApplicationContext is a shortcut to.)
 
 What's supported
 ================
 Only the basics.
-Setter and constructor injection work.
+Property and constructor injection work.
 Beans can be constructed from factories.
 Lookup methods work, but only if the bean doesn't get created by a factory.
 Scoping is really basic. Singleton is the default. Prototype is, in theory, supported.

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,13 @@
     "homepage": "http://github.com/moodev/bounce",
     "license": "ISC",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0",
+        "symfony/dependency-injection": ">=2.3.0 <2.8.0",
+        "symfony/config": ">=2.3.0 <2.8.0"
     },
     "require-dev": {
-        "ext-apc": ">=3.1.3",
-        "mockery/mockery": "dev-master"
+        "mockery/mockery": "~0.9.0",
+        "phpunit/phpunit": "~4.3.0"
     },
     "autoload": {
         "psr-0": {

--- a/lib/MooDev/Bounce/Config/BeanRefValueProvider.php
+++ b/lib/MooDev/Bounce/Config/BeanRefValueProvider.php
@@ -6,11 +6,11 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Priovides a value using a bean name, and returning the bean with that name
- * from the provided BeanFactory instance
+ * from the provided IBeanFactory instance
  *
  * @author steves
  */
@@ -28,7 +28,7 @@ class BeanRefValueProvider extends NoUndeclaredProperties implements ValueProvid
         $this->_beanName = $beanName;
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         return $beanFactory->createByName($this->_beanName);
     }

--- a/lib/MooDev/Bounce/Config/BeanValueProvider.php
+++ b/lib/MooDev/Bounce/Config/BeanValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Class that instantiates another bean based on a nested definition
@@ -26,7 +26,7 @@ class BeanValueProvider extends NoUndeclaredProperties implements ValueProvider
         $this->_bean = $bean;
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         return $beanFactory->create($this->_bean);
     }

--- a/lib/MooDev/Bounce/Config/Configurable.php
+++ b/lib/MooDev/Bounce/Config/Configurable.php
@@ -7,6 +7,9 @@
 
 namespace MooDev\Bounce\Config;
 
+/**
+ * Bounce will call the configure method after instantiating any class that implements this interface.
+ */
 interface Configurable
 {
 

--- a/lib/MooDev/Bounce/Config/ConstantValueProvider.php
+++ b/lib/MooDev/Bounce/Config/ConstantValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Provides a value from a global PHP constant
@@ -25,7 +25,7 @@ class ConstantValueProvider extends NoUndeclaredProperties implements ValueProvi
     /**
      * Returns the value of the defined constant name
      */
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         return defined($this->_constantName) ? constant($this->_constantName) : null;
     }

--- a/lib/MooDev/Bounce/Config/Context.php
+++ b/lib/MooDev/Bounce/Config/Context.php
@@ -17,10 +17,15 @@ class Context extends NoUndeclaredProperties
 
     /**
      * @var string a unique identifier for this context configuration. This will be used to
-     * reuse the same BeanFactory instance when creating the application context if context
+     * reuse the same IBeanFactory instance when creating the application context if context
      * sharing is enabled.
      */
     public $uniqueId = null;
+
+    /**
+     * @var string Path to the file that the context was loaded from.
+     */
+    public $fileName = null;
     
     /**
      * @var Bean[] keyed on the bean name that are directly defined
@@ -30,7 +35,7 @@ class Context extends NoUndeclaredProperties
 
     /**
      * @var Context[] list of child contexts which are referenced or
-     * imported by this context. This will be queried if the BeanFactory for this context requests
+     * imported by this context. This will be queried if the IBeanFactory for this context requests
      * a bean which is defined on an imported context.
      */
     public $childContexts = array();

--- a/lib/MooDev/Bounce/Config/FilePathValueProvider.php
+++ b/lib/MooDev/Bounce/Config/FilePathValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 use MooDev\Bounce\Exception\BounceException;
 
 /**
@@ -31,7 +31,7 @@ class FilePathValueProvider extends NoUndeclaredProperties implements ValueProvi
         $this->_rootDirectory = realpath(realpath(constant("DOC_DIR")) . "/../");
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         $filePath = $this->_joinPaths($this->_rootDirectory, $this->_relativePath);
         //Now turn this into a canonical file path so that we can check it's

--- a/lib/MooDev/Bounce/Config/ListValueProvider.php
+++ b/lib/MooDev/Bounce/Config/ListValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Value provider which takes a list of value providers and returns a list
@@ -28,7 +28,7 @@ class ListValueProvider extends NoUndeclaredProperties implements ValueProvider
         $this->_valueProviders = $valueProviders;
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         $outputArray = array();
         foreach ($this->_valueProviders as $valueProvider) {

--- a/lib/MooDev/Bounce/Config/LookupMethod.php
+++ b/lib/MooDev/Bounce/Config/LookupMethod.php
@@ -6,7 +6,6 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
 
 class LookupMethod extends NoUndeclaredProperties
 {

--- a/lib/MooDev/Bounce/Config/MapValueProvider.php
+++ b/lib/MooDev/Bounce/Config/MapValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Value provider which takes a map of value providers and returns a map
@@ -29,7 +29,7 @@ class MapValueProvider extends NoUndeclaredProperties implements ValueProvider
         $this->_valueProvidersMap = $valueProvidersMap;
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         $outputMap = array();
         foreach ($this->_valueProvidersMap as $mapIndex => $valueProvider) {

--- a/lib/MooDev/Bounce/Config/NullValueProvider.php
+++ b/lib/MooDev/Bounce/Config/NullValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Returns null as the value for a configuration item
@@ -15,7 +15,7 @@ use MooDev\Bounce\Context\BeanFactory;
  */
 class NullValueProvider implements ValueProvider
 {
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         return null;
     }

--- a/lib/MooDev/Bounce/Config/SimpleValueProvider.php
+++ b/lib/MooDev/Bounce/Config/SimpleValueProvider.php
@@ -6,7 +6,7 @@
  */
 
 namespace MooDev\Bounce\Config;
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 /**
  * Provides a simple value back. This is used for simple types
@@ -27,7 +27,7 @@ class SimpleValueProvider extends NoUndeclaredProperties implements ValueProvide
         $this->_value = $value;
     }
 
-    public function getValue(BeanFactory $beanFactory)
+    public function getValue(IBeanFactory $beanFactory)
     {
         return $this->_value;
     }

--- a/lib/MooDev/Bounce/Config/ValueProvider.php
+++ b/lib/MooDev/Bounce/Config/ValueProvider.php
@@ -7,15 +7,15 @@
 
 namespace MooDev\Bounce\Config;
 
-use MooDev\Bounce\Context\BeanFactory;
+use MooDev\Bounce\Context\IBeanFactory;
 
 interface ValueProvider
 {
     /**
      * Returns the value for the property from the configured provider object
      *
-     * @param $beanFactory BeanFactory a bean factory
+     * @param $beanFactory IBeanFactory a bean factory
      *                     instance that can be used to create nested beans.
      */
-    public function getValue(BeanFactory $beanFactory);
+    public function getValue(IBeanFactory $beanFactory);
 }

--- a/lib/MooDev/Bounce/Context/IBeanFactory.php
+++ b/lib/MooDev/Bounce/Context/IBeanFactory.php
@@ -6,6 +6,8 @@
  */
 namespace MooDev\Bounce\Context;
 
+use MooDev\Bounce\Config\Bean;
+
 /**
  * Thing that creates beans.
  */
@@ -23,5 +25,12 @@ interface IBeanFactory
      * @return string[] A map of bean names to class names.
      */
     public function getAllBeanClasses();
+
+    /**
+     * Create a bean based on a bean definition.
+     * @param Bean $_bean
+     * @return mixed
+     */
+    public function create(Bean $_bean);
 
 }

--- a/lib/MooDev/Bounce/Context/XmlContextParser.php
+++ b/lib/MooDev/Bounce/Context/XmlContextParser.php
@@ -74,6 +74,7 @@ class XmlContextParser implements IContextProvider
         $this->_phpTypeSafeParser = new TypeSafeParser("http://www.moo.com/xsd/bounce-php-1.0");
         $contextConfig = $this->_parseConfigXml($xmlContent);
         $contextConfig->uniqueId = $xmlFilePath;
+        $contextConfig->fileName = $xmlFilePath;
 
         //Remember that we've processed this, and pop it off the processing stack
         $this->_processedFiles[$xmlFilePath] = $contextConfig;

--- a/lib/MooDev/Bounce/Proxy/LookupMethodProxyGenerator.php
+++ b/lib/MooDev/Bounce/Proxy/LookupMethodProxyGenerator.php
@@ -108,7 +108,7 @@ class LookupMethodProxyGenerator {
             ->addProperty(new Property("__bounceBeanFactory", "null", "private"));
 
         $constructorBuilder = MethodBuilder::build("__construct")
-            ->addParam(new Param("__bounceBeanFactory", false, null, '\MooDev\Bounce\Context\BeanFactory'))
+            ->addParam(new Param("__bounceBeanFactory", false, null, '\MooDev\Bounce\Context\IBeanFactory'))
             ->addLine('$this->__bounceBeanFactory = $__bounceBeanFactory;');
 
         $rCon = $rClass->getConstructor();
@@ -119,11 +119,15 @@ class LookupMethodProxyGenerator {
             $superCallBuilder = CallBuilder::build("parent::__construct");
             foreach ($rParams as $param) {
                 $superCallBuilder->addParam('$' . $param->getName());
+                $default = "null";
+                if ($param->isDefaultValueAvailable()) {
+                    $default = var_export($param->getDefaultValue(), true);
+                }
                 $constructorBuilder->addParam(
                     new Param(
                         $param->getName(),
                         $param->isOptional(),
-                        ($param->isOptional() ? $param->getDefaultValue() : "null"),
+                        $default,
                         null, // Type hint information isn't available from ReflectionParameter for some reason :-(
                         $param->isPassedByReference()));
             }

--- a/lib/MooDev/Bounce/Symfony/BounceFileLoader.php
+++ b/lib/MooDev/Bounce/Symfony/BounceFileLoader.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+namespace MooDev\Bounce\Symfony;
+
+
+use MooDev\Bounce\Config\Context;
+use MooDev\Bounce\Context\XmlContextParser;
+use MooDev\Bounce\Proxy\ProxyGeneratorFactory;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\FileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * A Symfony Config FileLoader that will load a Bounce xml config into a Symfony DI container.
+ */
+class BounceFileLoader extends FileLoader
+{
+
+    /**
+     * @var string[]
+     */
+    private $customNamespaces;
+
+    /**
+     * @var ProxyGeneratorFactory
+     */
+    private $proxyGeneratorFactory;
+
+    /**
+     * BounceFileLoader constructor.
+     * @param ContainerBuilder $container Container to load the config into.
+     * @param FileLocatorInterface $locator Locator that'll be used to lookup files.
+     * @param ProxyGeneratorFactory $proxyGeneratorFactory A proxy generator for lookup methods
+     * @param string[] $customNamespaces Map of custom namespace names to ValueProviders for that namespace.
+     */
+    public function __construct(ContainerBuilder $container, FileLocatorInterface $locator, ProxyGeneratorFactory $proxyGeneratorFactory = null, $customNamespaces = [])
+    {
+        parent::__construct($container, $locator);
+        $this->proxyGeneratorFactory = $proxyGeneratorFactory;
+        $this->customNamespaces = $customNamespaces;
+    }
+
+    /**
+     * Loads a resource.
+     *
+     * @param mixed $resource The resource
+     * @param string|null $type The resource type or null if unknown
+     *
+     * @throws \Exception If something went wrong
+     */
+    public function load($resource, $type = null)
+    {
+        $path = $this->locator->locate($resource);
+
+        $bounceParser = new XmlContextParser($path, $this->customNamespaces);
+        $bounceContext = $bounceParser->getContext();
+
+        $this->importContext($bounceContext);
+
+
+    }
+
+    /**
+     * Returns whether this class supports the given resource.
+     *
+     * @param mixed $resource A resource
+     * @param string|null $type The resource type or null if unknown
+     *
+     * @return bool True if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) && 'xml' === pathinfo($resource, PATHINFO_EXTENSION);
+    }
+
+    private function registerConfigurator()
+    {
+        $name = "bounceConfigurableConfigurator";
+        if (!$this->container->has($name)) {
+            $this->container->setDefinition($name, new Definition('MooDev\Bounce\Symfony\SymfonyConfigurator'));
+        }
+        return [new Reference($name), 'configure'];
+    }
+
+    protected function importContext(Context $context) {
+        $lookupProxyGenerator = null;
+        if ($this->proxyGeneratorFactory) {
+            $lookupProxyGenerator = $this->proxyGeneratorFactory->getLookupMethodProxyGenerator($context->uniqueId);
+        }
+
+        $configurator = $this->registerConfigurator();
+
+        $configBeanFactory = new SymfonyConfigBeanFactory($configurator, $lookupProxyGenerator);
+        foreach ($context->childContexts as $childContext) {
+            $this->importContext($childContext);
+        }
+        foreach ($context->beans as $bean) {
+            if (empty($bean->name)) {
+                // TODO: wat.
+                continue;
+            }
+            $this->container->setDefinition($bean->name, $configBeanFactory->create($bean));
+        }
+        $this->container->addResource(new FileResource($context->fileName));
+    }
+
+}

--- a/lib/MooDev/Bounce/Symfony/DefaultLoaderFactory.php
+++ b/lib/MooDev/Bounce/Symfony/DefaultLoaderFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+
+namespace MooDev\Bounce\Symfony;
+
+
+use MooDev\Bounce\Proxy\ProxyGeneratorFactory;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A Loader Factory that loads files using the BounceFileLoader only.
+ */
+class DefaultLoaderFactory implements LoaderFactory
+{
+
+    private $customNamespaces;
+
+    private $proxyGeneratorFactory;
+
+    /**
+     * DefaultLoaderFactory constructor.
+     * @param string[] $customNamespaces
+     * @param ProxyGeneratorFactory $proxyGeneratorFactory A proxy generator factory, or null to disable lookup methods.
+     */
+    public function __construct(array $customNamespaces = [], ProxyGeneratorFactory $proxyGeneratorFactory = null)
+    {
+        $this->proxyGeneratorFactory = $proxyGeneratorFactory;
+        $this->customNamespaces = $customNamespaces;
+    }
+
+
+    /**
+     * @param ContainerInterface $container
+     * @return LoaderInterface
+     */
+    public function getLoader(ContainerInterface $container)
+    {
+        $fileLocator = new FileLocator();
+        return new BounceFileLoader($container, $fileLocator, $this->proxyGeneratorFactory, $this->customNamespaces);
+    }
+}

--- a/lib/MooDev/Bounce/Symfony/LoaderFactory.php
+++ b/lib/MooDev/Bounce/Symfony/LoaderFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+
+namespace MooDev\Bounce\Symfony;
+
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Interface for obtaining Symfony config loaders for a Container.
+ */
+interface LoaderFactory
+{
+
+    /**
+     * @param ContainerInterface $container Container that'll be loaded into.
+     * @return LoaderInterface
+     */
+    public function getLoader(ContainerInterface $container);
+
+}

--- a/lib/MooDev/Bounce/Symfony/SymfonyApplicationContext.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyApplicationContext.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+namespace MooDev\Bounce\Symfony;
+
+use MooDev\Bounce\Context\ApplicationContext;
+use MooDev\Bounce\Proxy\ProxyGeneratorFactory;
+use MooDev\Bounce\Proxy\Store\FilesProxyStore;
+use MooDev\Bounce\Proxy\Store\InMemoryProxyStore;
+use MooDev\Bounce\Proxy\Utils\Base32Hex;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+
+/**
+ * ApplicationContext that uses Symfony's DI framework and Bounce's config loader.
+ */
+class SymfonyApplicationContext extends ApplicationContext
+{
+
+    /**
+     * @return ContainerInterface
+     */
+    protected function getContainerBuilderCached($contextFile, $cacheDir, $isDebug, $loaderFactory)
+    {
+        $contextFile = realpath($contextFile);
+
+        $file = $cacheDir . '/' . basename($contextFile) . '.cache';
+        $className = "c" . Base32Hex::encode($contextFile);
+
+        $containerConfigCache = new ConfigCache($file, $isDebug);
+
+        if (!$containerConfigCache->isFresh()) {
+            $containerBuilder = $this->buildContainer($contextFile, $loaderFactory);
+
+            $dumper = new PhpDumper($containerBuilder);
+            $containerConfigCache->write(
+                $dumper->dump(array('class' => $className)),
+                $containerBuilder->getResources()
+            );
+        }
+
+        require_once $file;
+        return new $className();
+    }
+
+    /**
+     * SymfonyApplicationContext constructor.
+     * Note, Bounce's import code currently will NOT use Symfony's config loaders, it will use a bounce internal file
+     * loader. Non bounce configs cannot be imported from a bounce context.
+     * However, by passing a different LoaderFactory to this constructor you can load something that isn't a bounce
+     * context into a new container wrapped to look like bounce.... potentially that config could include a bounce
+     * context itself... Though your Loader will need to deal with both Symfony's XMLFileLoader and the BounceFileLoader
+     * claiming the .xml file extension!
+     *
+     * @param string $contextFile Bounce context to load
+     * @param string[] $customNamespaces Map of namespace names to ValueProvider of any custom namespaces.
+     * @param string $cacheDir Directory that cached proxies and the compiled context should be loaded into. If this is
+     * null, you will have no caching. Compilation will be required every single time this is constructed, and be slow.
+     * @param bool $isDebug If true, check that the compiled context cache isn't stale every request.
+     * @param LoaderFactory $loaderFactory Alternative Symfony config loader to use to load $contextFile.
+     */
+    public function __construct($contextFile, array $customNamespaces = [], $cacheDir = null, $isDebug = false, LoaderFactory $loaderFactory = null)
+    {
+        if ($loaderFactory === null) {
+            if ($cacheDir) {
+                $proxyStore = new FilesProxyStore($cacheDir . DIRECTORY_SEPARATOR . 'proxies');
+            } else {
+                $proxyStore = new InMemoryProxyStore();
+            }
+            $proxyGeneratorFactory = new ProxyGeneratorFactory($proxyStore);
+            $loaderFactory = new DefaultLoaderFactory($customNamespaces, $proxyGeneratorFactory);
+        }
+
+        if ($cacheDir) {
+            $containerBuilder = $this->getContainerBuilderCached($contextFile, $cacheDir, $isDebug, $loaderFactory);
+        } else {
+            $containerBuilder = $this->buildContainer($contextFile, $loaderFactory);
+        }
+
+        parent::__construct(new SymfonyContainerBeanFactory($containerBuilder));
+    }
+
+    protected function buildContainer($contextFile, LoaderFactory $loaderFactory) {
+        $containerBuilder = new ContainerBuilder();
+
+        $loader = $loaderFactory->getLoader($containerBuilder);
+        $loader->load($contextFile);
+
+        $containerBuilder->compile();
+        return $containerBuilder;
+    }
+
+}

--- a/lib/MooDev/Bounce/Symfony/SymfonyAwareValueProvider.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyAwareValueProvider.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+namespace MooDev\Bounce\Symfony;
+
+
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * A value provider that returns Symfony Definitions/References.
+ * These are useless to vanilla bounce (you need to implement the normal ValueProvider interface for that.)
+ * You can implement both interfaces, in which case the Symfony implementations will prefer this interface
+ * over the normal ValueProvider.
+ */
+interface SymfonyAwareValueProvider
+{
+    /***
+     * @return mixed|Definition|Reference
+     */
+    public function getSymfonyValue();
+}

--- a/lib/MooDev/Bounce/Symfony/SymfonyConfigBeanFactory.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyConfigBeanFactory.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace MooDev\Bounce\Symfony;
+
+use MooDev\Bounce\Config\Bean;
+use MooDev\Bounce\Config\ValueProvider;
+use MooDev\Bounce\Context\IBeanFactory;
+use MooDev\Bounce\Exception\BounceException;
+use MooDev\Bounce\Proxy\LookupMethodProxyGenerator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Bean factory that converts bean definitions and references into Symfony DI config elements (rather than instances
+ * of the bean.)
+ *
+ * This is an internal implementation detail of the BounceFileLoader, and might be considered "a bit of a hack."
+ */
+class SymfonyConfigBeanFactory implements IBeanFactory
+{
+
+    /**
+     * @var LookupMethodProxyGenerator
+     */
+    private $proxyGeneratorFactory;
+
+    /**
+     * @var array
+     */
+    private $configurator;
+
+    /**
+     * SymfonyConfigBeanFactory constructor.
+     * @param array $configurator
+     * @param LookupMethodProxyGenerator $proxyGeneratorFactory
+     */
+    public function __construct(array $configurator = null, LookupMethodProxyGenerator $proxyGeneratorFactory = null)
+    {
+        $this->proxyGeneratorFactory = $proxyGeneratorFactory;
+        $this->configurator = $configurator;
+    }
+
+
+    /**
+     * Create/retrieve an instance of a named bean.
+     * @param string $name
+     * @return mixed
+     */
+    public function createByName($name)
+    {
+        return new Reference($name);
+    }
+
+    /**
+     * @return string[] A map of bean names to class names.
+     */
+    public function getAllBeanClasses()
+    {
+        throw new \RuntimeException("Not implemented");
+    }
+
+    protected function getConfigurator()
+    {
+        // The configurator will call configure() on the instantiated bean if it implements Configurable.
+        return $this->configurator;
+    }
+
+    protected function getBeanFactory()
+    {
+        // TODO: Make this a ref to a common bean?
+        // Return a bean factory that just obtains beans from the service container.
+        $def = new Definition('MooDev\Bounce\Symfony\SymfonyContainerBeanFactory');
+        $def->addArgument(new Reference('service_container')); // service_container is a magical service: the container itself.
+        return $def;
+    }
+
+    protected function convertValueProviderToValue($valueProvider) {
+        if ($valueProvider instanceof SymfonyAwareValueProvider) {
+            return $valueProvider->getSymfonyValue();
+        } else {
+            /**
+             * @var ValueProvider $valueProvider
+             */
+            return $valueProvider->getValue($this);
+        }
+    }
+
+    /**
+     * @param Bean $bean
+     * @return mixed
+     */
+    public function create(Bean $bean)
+    {
+        $useConfigurator = true;
+        $originalClass = $class = ltrim($bean->class, '\\');
+        if ($bean->factoryMethod) {
+            // We don't have a clue what what the real class is, fake it and hope nothing breaks;
+            $class = "stdClass";
+        } else {
+            if (class_exists($class)) {
+                $rClass = new \ReflectionClass($class);
+                if (!$rClass->implementsInterface('MooDev\Bounce\Config\Configurable')) {
+                    // The class definitely doesn't need the configurator, so we can disable it.
+                    $useConfigurator = false;
+                }
+            }
+        }
+
+        $usesLookupMethods = false;
+        if ($bean->lookupMethods) {
+            if (!$this->proxyGeneratorFactory) {
+                throw new BounceException("Proxy generator not configured, cannot use lookup-method");
+            }
+            // If we have lookup methods then the class is actually a generated proxy.
+            $class = ltrim($this->proxyGeneratorFactory->loadProxy($bean), '\\');
+            $usesLookupMethods = true;
+        }
+
+        $def = new Definition($class);
+
+        if ($usesLookupMethods) {
+            // The proxy will take an additional, first, constructor arg which is expected to be a bean factory.
+            $def->addArgument($this->getBeanFactory());
+        }
+
+        if ($useConfigurator) {
+            // We use the configurator if we know the class of the bean and it implements Configurable
+            // or if we have no idea what the class of the bean is (there's a factory method.)
+            $def->setConfigurator($this->getConfigurator());
+        }
+
+        if ($bean->scope) {
+            // This is getting killed off in Symfony 3. Sigh.
+            // TODO: deal with Symfony 3.
+            switch ($bean->scope) {
+                case "singleton":
+                    $def->setScope(ContainerBuilder::SCOPE_CONTAINER);
+                    break;
+                case "prototype":
+                    $def->setScope(ContainerBuilder::SCOPE_PROTOTYPE);
+                    break;
+                default:
+                    $def->setScope($bean->scope);
+            }
+        }
+
+        foreach ($bean->constructorArguments as $constructorArgument) {
+            $def->addArgument($this->convertValueProviderToValue($constructorArgument));
+        }
+
+        foreach ($bean->properties as $name => $property) {
+            // TODO: Could support setter injection using Reflection here?
+            $def->setProperty($name, $this->convertValueProviderToValue($property));
+        }
+
+        if ($bean->factoryBean) {
+            $def->setFactoryService($bean->factoryBean);
+            $def->setFactoryMethod($bean->factoryMethod);
+        } elseif ($bean->factoryMethod) {
+            $def->setFactoryClass($originalClass);
+            $def->setFactoryMethod($bean->factoryMethod);
+        }
+
+        return $def;
+    }
+}

--- a/lib/MooDev/Bounce/Symfony/SymfonyConfigurator.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyConfigurator.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+namespace MooDev\Bounce\Symfony;
+
+
+use MooDev\Bounce\Config\Configurable;
+
+/**
+ * Symfony Configurator for configuring Bounce Configurables.
+ *
+ * Internal implementation detail of the SymfonyConfigBeanFactory.
+ */
+class SymfonyConfigurator
+{
+
+    /**
+     * @param object $thing A newly instantiated thing to configure.
+     */
+    public function configure($thing)
+    {
+        // We will get called for non-Configurables due to it being impossible to work out whether or not things will
+        // actually implement this interface at context compilation time. The bean factory falls back to using a
+        // configurable if it isn't definitely sure what the class of the instantiated bean will be.
+        if ($thing instanceof Configurable) {
+            $thing->configure();
+        }
+    }
+
+}

--- a/lib/MooDev/Bounce/Symfony/SymfonyContainerBeanFactory.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyContainerBeanFactory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @author Jonathan Oddy <jonathan@moo.com>
+ * @copyright Copyright (c) 2015, MOO Print Ltd.
+ * @license ISC
+ */
+namespace MooDev\Bounce\Symfony;
+
+
+use MooDev\Bounce\Config\Bean;
+use MooDev\Bounce\Context\IBeanFactory;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * A BeanFactory that retrieves services from a Symfony container.
+ */
+class SymfonyContainerBeanFactory implements IBeanFactory
+{
+
+    private $container;
+
+    public function __construct(ContainerInterface $container) {
+        $this->container = $container;
+    }
+
+    /**
+     * Create/retrieve an instance of a named bean.
+     * @param string $name
+     * @return mixed
+     */
+    public function createByName($name)
+    {
+        return $this->container->get($name);
+    }
+
+    /**
+     * @return string[] A map of bean names to class names.
+     */
+    public function getAllBeanClasses()
+    {
+        throw new \RuntimeException("Not implemented.");
+    }
+
+    /**
+     * @param Bean $_bean
+     * @return mixed
+     */
+    public function create(Bean $_bean)
+    {
+        throw new \RuntimeException("Not implemented.");
+    }
+
+}

--- a/tests/MooDev/Bounce/Symfony/SymfonyApplicationContextTest.php
+++ b/tests/MooDev/Bounce/Symfony/SymfonyApplicationContextTest.php
@@ -1,0 +1,338 @@
+<?php
+namespace MooDev\Bounce\Symfony;
+use MooDev\Bounce\Context\ValueTagProvider;
+use SimpleXMLElement;
+use MooDev\Bounce\Config;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+class SymfomnyApplicationContextTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testLoadFullXml()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $this->assertNotNull($xmlContext->get("one"));
+        $one = $xmlContext->get("one");
+        $this->assertEquals("Hello!", $one->const);
+        $this->assertEquals("simpleString", $one->simpleString);
+        $this->assertEquals(2, $one->simpleInt);
+        $this->assertEquals(2.3, $one->simpleFloat);
+        $this->assertEquals("implicitString", $one->implicitString);
+        $this->assertEquals(4, $one->implicitInt);
+        $this->assertEquals(3.2, $one->implicitFloat);
+        $this->assertEquals("explicitString", $one->explicitString);
+        $this->assertEquals(4, $one->explicitInt);
+        $this->assertEquals(3.2, $one->explicitFloat);
+        $this->assertTrue($one->explicitBool);
+    }
+
+    public function testNestedBean()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $one = $xmlContext->get("one");
+        //Now look at the parent bean
+        $two = $xmlContext->get("two");
+        $this->assertEquals($one, $two->childByRef);
+        $this->assertEquals("test!", $two->childByDefinition->testNestedBeanProp);
+    }
+
+    public function testFileObject()
+    {
+        $rootDir = realpath(__DIR__ . '/../../../../');
+        if (!defined("ROOT_DIR")) {
+            define("ROOT_DIR", $rootDir);
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $fileReader = $xmlContext->get("fileReader");
+        $this->assertEquals($rootDir . "/build.xml", $fileReader->file);
+    }
+
+    public function testNullObject()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $nullObj = $xmlContext->get("nullType");
+        $this->assertNull($nullObj->prop);
+    }
+
+    public function testMapObject()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $mapBean = $xmlContext->get("mapBean");
+        $this->assertEquals("steve", $mapBean->map["one"]);
+        $this->assertEquals("simon", $mapBean->map["two"]);
+    }
+
+    public function testListObject()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/fullContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $listBean = $xmlContext->get("listBean");
+        $this->assertEquals("steve", $listBean->list[0]);
+        $this->assertEquals("simon", $listBean->list[1]);
+        $this->assertEquals($xmlContext->get("fileReader"), $listBean->list[2]);
+    }
+
+    public function testImportChild()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/parent.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $parentBean = $xmlContext->get("parentBean");
+        $this->assertEquals("simpleString", $parentBean->child->simpleString);
+    }
+
+
+    public function testImportChain()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/grandparent.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $grandParentBean = $xmlContext->get("grandParentBean");
+        $this->assertEquals("simpleString", $grandParentBean->grandchild->simpleString);
+    }
+
+    public function testResolutionViaSiblings()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/parentOfTwo.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $elderBrotherBean = $xmlContext->get("elderBrotherBean");
+        $this->assertEquals("simpleString", $elderBrotherBean->sibling->simpleString);
+    }
+
+    public function testResolutionViaCodependentSiblings()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/cofamily.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $a = $xmlContext->get("a");
+        $this->assertEquals("simpleString", $a->thing->thing->thing);
+    }
+
+    public function testResolutionViaParentFactory()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/factoryParent.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $childBean = $xmlContext->get("childBean");
+        $this->assertEquals("simpleString", $childBean->getThing());
+    }
+
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage Infinite recursion import detected
+     */
+    public function testObviousImportLoop()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/selfImporting.xml";
+        new SymfonyApplicationContext($xmlFile);
+    }
+
+    /**
+     * @expectedException \MooDev\Bounce\Exception\BounceException
+     * @expectedExceptionMessage Infinite recursion import detected
+     */
+    public function testTransitiveImportLoop()
+    {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/loopParent.xml";
+        new SymfonyApplicationContext($xmlFile);
+    }
+
+    public function testCustomNS() {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/customContext.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile, array("http://www.moo.com/xsd/fictional-1.0" => new TestAdditionalProvider()));
+        $customBean = $xmlContext->get("customBean");
+        $this->assertEquals("Testing", $customBean->custom);
+    }
+
+    public function testSimpleScope() {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/scopes.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $beanOne = $xmlContext->get("two");
+        $beanTwo = $xmlContext->get("four");
+        $this->assertEquals("foo", $beanOne->goats->hi);
+        $this->assertEquals("foo", $beanTwo->badgers->hi);
+        $this->assertSame($beanOne->goats, $beanTwo->badgers);
+
+    }
+
+   public function testProxyScope() {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/scopes.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile);
+        $beanOne = $xmlContext->get("three");
+        $beanTwo = $xmlContext->get("three");
+        $this->assertSame($beanOne, $beanTwo);
+        $this->assertEquals("foo", $beanOne->goats()->hi);
+        $this->assertEquals("foo", $beanTwo->goats()->hi);
+        $this->assertNotSame($beanOne->goats(), $beanTwo->goats());
+        $this->assertNotSame($beanOne->goats(), $beanOne->goats());
+
+    }
+
+    protected function _getProxyDir()
+    {
+        do {
+            $path = tempnam(sys_get_temp_dir(), 'bounce_');
+            @unlink($path);
+        } while (!@mkdir($path, 0777, true)); // If this failed, we lost a race. Try again.
+        return $path;
+    }
+
+    public function testProxyScopeWithDiskCache() {
+        if (!defined("DOC_DIR")) {
+            define("DOC_DIR", realpath(__DIR__ . '/../../../'));
+        }
+        if (!defined("SIMPLE_CONSTANT")) {
+            define("SIMPLE_CONSTANT", "Hello!");
+        }
+        $xmlFile = __DIR__ . "/scopes.xml";
+        $xmlContext = new SymfonyApplicationContext($xmlFile, [], $this->_getProxyDir());
+        $beanOne = $xmlContext->get("three");
+        $beanTwo = $xmlContext->get("three");
+        $this->assertSame($beanOne, $beanTwo);
+        $this->assertEquals("foo", $beanOne->goats()->hi);
+        $this->assertEquals("foo", $beanTwo->goats()->hi);
+        $this->assertNotSame($beanOne->goats(), $beanTwo->goats());
+        $this->assertNotSame($beanOne->goats(), $beanOne->goats());
+
+    }
+
+}
+
+class TestAdditionalProvider implements ValueTagProvider {
+
+    /**
+     * @param SimpleXMLElement $element
+     * @param Config\Context $contextConfig
+     * @return Config\ValueProvider
+     */
+    public function getValueProvider(SimpleXMLElement $element, Config\Context $contextConfig)
+    {
+
+        $name = $element->getName();
+        if ($name == "test") {
+            return new Config\SimpleValueProvider($element);
+        }
+        return null;
+
+    }
+}
+
+class ParentBean {
+
+    public $thing;
+
+    public function getInstance()
+    {
+        return new ChildBean($this->thing);
+    }
+}
+
+class ChildBean {
+
+    private $thing;
+
+    public function __construct($thing)
+    {
+        $this->thing = $thing;
+    }
+
+    public function getThing()
+    {
+        return $this->thing;
+    }
+}

--- a/tests/MooDev/Bounce/Symfony/child.xml
+++ b/tests/MooDev/Bounce/Symfony/child.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+    <bean id="childBean" class="StdClass">
+        <property name="simpleString" value="simpleString" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/child1.xml
+++ b/tests/MooDev/Bounce/Symfony/child1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="elderBrotherBean" class="StdClass">
+        <property name="sibling" ref="youngerBrotherBean" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/child2.xml
+++ b/tests/MooDev/Bounce/Symfony/child2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean id="youngerBrotherBean" class="StdClass">
+        <property name="simpleString" value="simpleString" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/cochild1.xml
+++ b/tests/MooDev/Bounce/Symfony/cochild1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="a" class="StdClass">
+        <property name="thing" ref="x" />
+    </bean>
+
+    <bean name="b" class="StdClass">
+        <property name="thing" value="simpleString" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/cochild2.xml
+++ b/tests/MooDev/Bounce/Symfony/cochild2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="x" class="StdClass">
+        <property name="thing" ref="b" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/cofamily.xml
+++ b/tests/MooDev/Bounce/Symfony/cofamily.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <import path="cochild1.xml"/>
+    <import path="cochild2.xml"/>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/customContext.xml
+++ b/tests/MooDev/Bounce/Symfony/customContext.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xmlns:fictional="http://www.moo.com/xsd/fictional-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+            http://www.moo.com/xsd/fictional-1.0 http://www.moo.com/xsd/fictional-1.0
+">
+
+    <bean name="customBean" class="StdClass">
+        <property name="custom">
+            <fictional:test>Testing</fictional:test>
+        </property>
+    </bean>
+</beans>

--- a/tests/MooDev/Bounce/Symfony/factoryChild.xml
+++ b/tests/MooDev/Bounce/Symfony/factoryChild.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="childBean" factory-bean="parentBean" factory-method="getInstance">
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/factoryParent.xml
+++ b/tests/MooDev/Bounce/Symfony/factoryParent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="parentBean" class="\MooDev\Bounce\Symfony\ParentBean">
+        <property name="thing" value="simpleString" />
+    </bean>
+
+    <import path="factoryChild.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/fullContext.xml
+++ b/tests/MooDev/Bounce/Symfony/fullContext.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+    <bean id="one" class="StdClass">
+        <property name="simpleString" value="simpleString" />
+        <property name="simpleInt" value="2" />
+        <property name="simpleFloat" value="2.3" />
+        <property name="const">
+            <php:constant name="SIMPLE_CONSTANT" />
+        </property>
+        <property name="implicitString">
+            <value>implicitString</value>
+        </property>
+        <property name="implicitInt">
+            <value>4</value>
+        </property>
+        <property name="implicitFloat">
+            <value>3.2</value>
+        </property>
+        <property name="explicitString">
+            <php:string>explicitString</php:string>
+        </property>
+        <property name="explicitInt">
+            <php:int>4</php:int>
+        </property>
+        <property name="explicitFloat">
+            <php:float>3.2</php:float>
+        </property>
+        <property name="explicitBool">
+            <php:bool>true</php:bool>
+        </property>
+    </bean>
+
+    <bean name="two" class="StdClass">
+        <property name="childByRef" ref="one" />
+        <property name="childByDefinition">
+            <bean class="StdClass">
+                <property name="testNestedBeanProp" value="test!" />
+            </bean>
+        </property>
+    </bean>
+
+    <bean name="fileReader" class="StdClass">
+        <property name="file">
+            <php:file>build.xml</php:file>
+        </property>
+    </bean>
+
+    <bean name="nullType" class="StdClass">
+        <property name="prop">
+            <null />
+        </property>
+    </bean>
+
+    <bean name="mapBean" class="StdClass">
+        <property name="map">
+            <map>
+                <entry name="one">
+                    <value>steve</value>
+                </entry>
+                <entry name="two">
+                    <value>simon</value>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
+    <bean name="listBean" class="StdClass">
+        <property name="list">
+            <list>
+                <value>steve</value>
+                <value>simon</value>
+                <bean ref="fileReader" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="three" class="StdClass">
+        <property name="hi"><value>foo</value></property>
+    </bean>
+
+    <bean name="four" class="StdClass">
+        <property name="goats" ref="three" />
+        <property name="stoats">
+            <bean name="blar" class="StdClass" />
+        </property>
+    </bean>
+
+    <bean name="five" class="StdClass">
+        <lookup-method name="goats" bean="three" />
+    </bean>
+</beans>

--- a/tests/MooDev/Bounce/Symfony/grandparent.xml
+++ b/tests/MooDev/Bounce/Symfony/grandparent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="grandParentBean" class="StdClass">
+        <property name="grandchild" ref="childBean" />
+    </bean>
+
+    <import path="parent.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/loopChild.xml
+++ b/tests/MooDev/Bounce/Symfony/loopChild.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <import path="loopParent.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/loopParent.xml
+++ b/tests/MooDev/Bounce/Symfony/loopParent.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <import path="loopChild.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/parent.xml
+++ b/tests/MooDev/Bounce/Symfony/parent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <bean name="parentBean" class="StdClass">
+        <property name="child" ref="childBean" />
+    </bean>
+
+    <import path="child.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/parentOfTwo.xml
+++ b/tests/MooDev/Bounce/Symfony/parentOfTwo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <import path="child1.xml" />
+    <import path="child2.xml" />
+</beans>

--- a/tests/MooDev/Bounce/Symfony/scopes.xml
+++ b/tests/MooDev/Bounce/Symfony/scopes.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+    <bean id="one" class="StdClass">
+        <property name="hi"><value>foo</value></property>
+    </bean>
+
+    <bean name="two" class="StdClass" scope="prototype">
+        <property name="goats" ref="one" />
+        <property name="stoats">
+            <bean name="blar" class="StdClass" />
+        </property>
+    </bean>
+
+    <bean name="four" class="StdClass" scope="prototype">
+        <property name="badgers" ref="one" />
+    </bean>
+
+    <bean name="five" class="StdClass" scope="prototype">
+        <property name="hi"><value>foo</value></property>
+    </bean>
+
+    <bean name="three" class="StdClass">
+        <lookup-method name="goats" bean="five" />
+    </bean>
+
+</beans>

--- a/tests/MooDev/Bounce/Symfony/selfImporting.xml
+++ b/tests/MooDev/Bounce/Symfony/selfImporting.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.moo.com/xsd/bounce-beans-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:php="http://www.moo.com/xsd/bounce-php-1.0"
+    xsi:schemaLocation="
+            http://www.moo.com/xsd/bounce-beans-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-beans-1.0.xsd
+            http://www.moo.com/xsd/bounce-php-1.0 file:///home/steves/moo/lib/moocommon-infra/src/resources/bounce-php-1.0.xsd
+">
+
+    <import path="selfImporting.xml" />
+</beans>


### PR DESCRIPTION
Refactor the context loading code into a Symfony Loader.
This allows (in theory):
* Bounce contexts to be loaded from a normal Symfony setup.
** Caveat: Symfony's XML file loader will try to load bounce contexts, bounce will try to load Symfony XML files. Both will fail. Probably need a loader that filters file paths...
* Symfony configs to be loaded into bounce (with bounce creating and owning the container.)