### PR TITLE
Make cached app context file name match class name.

### DIFF
--- a/lib/MooDev/Bounce/Symfony/SymfonyApplicationContext.php
+++ b/lib/MooDev/Bounce/Symfony/SymfonyApplicationContext.php
@@ -29,8 +29,9 @@ class SymfonyApplicationContext extends ApplicationContext
     {
         $contextFile = realpath($contextFile);
 
-        $file = $cacheDir . '/' . basename($contextFile) . '.cache';
         $className = "c" . Base32Hex::encode($contextFile);
+
+        $file = $cacheDir . '/' . $className;
 
         $containerConfigCache = new ConfigCache($file, $isDebug);
 


### PR DESCRIPTION
Class name contains the full path to the context file, it's important the cache
file also does since we might have collisions due to same names but different paths.
It also mucks up how moo does releases if we don't do this.

This is not ideal, and may hit filesystem limits... a better fix will need to come later.