### PR TITLE
Fix Travis for PHP 5.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - composer require symfony/dependency-injection:${SYMFONY_VERSION} symfony/config:${SYMFONY_VERSION}
   - composer install --dev
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
The container used by Travis for PHP 5.4 has problems with PHPUnit. You can use the one installed by composer instead.